### PR TITLE
fix bug in Get-DscResource

### DIFF
--- a/src/PSDesiredStateConfiguration/PSDesiredStateConfiguration.psm1
+++ b/src/PSDesiredStateConfiguration/PSDesiredStateConfiguration.psm1
@@ -3980,12 +3980,14 @@ function Get-DscResource
                 $nameMessage = $LocalizedData.GetDscResourceInputName -f @('Name', [system.string]::Join(', ', $Name))
                 Write-Verbose -Message $nameMessage
             }
-            if($Module -and !$modules)
+
+            if(!$modules)
             {
                 #Return if no modules were found with the required specification
                 Write-Warning -Message $LocalizedData.NoModulesPresent
                 return
             }
+
             $ignoreResourceParameters = @('InstanceName', 'OutputPath', 'ConfigurationData') + [System.Management.Automation.Cmdlet]::CommonParameters + [System.Management.Automation.Cmdlet]::OptionalCommonParameters
 
             $patterns = GetPatterns $Name


### PR DESCRIPTION
sometimes we would fail on 
```
GetResourceFromKeyword -keyword $_ -patterns $patterns -modules $modules
```
if modules was empty

fix for #11  should be merged first and test enabled