### PR TITLE
get delimiter for splitting psmodulepath

### DIFF
--- a/src/PSDesiredStateConfiguration/PSDesiredStateConfiguration.psm1
+++ b/src/PSDesiredStateConfiguration/PSDesiredStateConfiguration.psm1
@@ -3842,7 +3842,7 @@ function ReadEnvironmentFile
 
 function Get-DSCResourceModules
 {
-    $listPSModuleFolders = $env:PSModulePath.Split(":")
+    $listPSModuleFolders = $env:PSModulePath.Split([IO.Path]::PathSeparator)
     $dscModuleFolderList = [System.Collections.Generic.HashSet[System.String]]::new()
 
     foreach ($folder in $listPSModuleFolders)


### PR DESCRIPTION
This will work cross-platform. Full credit - the idea came from Mike Lombardi at Puppet. He was looking at the .psm1 file on his Windows machine and brought this up in Slack.