### PR TITLE
Updated required PS version

### DIFF
--- a/src/PSDesiredStateConfiguration/PSDesiredStateConfiguration.psd1
+++ b/src/PSDesiredStateConfiguration/PSDesiredStateConfiguration.psd1
@@ -30,7 +30,7 @@ Copyright = '(c) Microsoft Corporation. All rights reserved.'
 Description = 'PowerShell Desired State Configuration'
 
 # Minimum version of the Windows PowerShell engine required by this module
-PowerShellVersion = '7.1'
+PowerShellVersion = '7.2'
 
 # Name of the Windows PowerShell host required by this module
 # PowerShellHostName = ''
@@ -63,7 +63,7 @@ PowerShellVersion = '7.1'
 # FormatsToProcess = @()
 
 # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
- NestedModules = @('Microsoft.PowerShell.DscSubsystem.dll')
+NestedModules = @('Microsoft.PowerShell.DscSubsystem.dll')
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
 FunctionsToExport = @(


### PR DESCRIPTION
Updating to `PowerShellVersion = '7.2' ` in module manifest.
Side note: Preview specifications are not supported in this field, showing this error:
`Cannot convert value "7.2-Preview.6" to type "System.Version". Error: "Input string was not in a correct format."`,
however PS `7.2.0-preview.5` can load a module with `PowerShellVersion = '7.2' ` in module manifest just fine.