### PR TITLE
Added Prerelease-beta1 to module version, tags and ProjectUri

### DIFF
--- a/src/PSDesiredStateConfiguration/PSDesiredStateConfiguration.psd1
+++ b/src/PSDesiredStateConfiguration/PSDesiredStateConfiguration.psd1
@@ -101,6 +101,13 @@ HelpInfoURI = 'https://go.microsoft.com/fwlink/?linkid=2113535'
 
 PrivateData = @{
     PSData = @{
+        Prerelease = 'beta1'
+        Tags         = @('PSDesiredStateConfiguration',
+            'PSEdition_Core',
+            'Linux',
+            'Mac',
+            'Windows')
+        ProjectUri   = 'https://github.com/PowerShell/PSDesiredStateConfiguration'
         ExperimentalFeatures = @(
                 @{
                     Name = 'PSDesiredStateConfiguration.InvokeDscResource'


### PR DESCRIPTION
At this point, v3.0.0 of the module should be a PreRelease, so marking it as `beta1`.
Also updated Tags, used by PS Gallery and ProjectUri link.

![DSCModule-Beta1Capture](https://user-images.githubusercontent.com/11860095/120399985-e633e680-c2f1-11eb-9069-17356dde6a85.PNG)
