### PR TITLE
Remove PSDesiredStateConfiguration.InvokeDscResource experimental feature.

### DIFF
--- a/src/PSDesiredStateConfiguration/PSDesiredStateConfiguration.psd1
+++ b/src/PSDesiredStateConfiguration/PSDesiredStateConfiguration.psd1
@@ -108,13 +108,6 @@ PrivateData = @{
             'Mac',
             'Windows')
         ProjectUri   = 'https://github.com/PowerShell/PSDesiredStateConfiguration'
-        ExperimentalFeatures = @(
-                @{
-                    Name = 'PSDesiredStateConfiguration.InvokeDscResource'
-                    Description = "Enables the Invoke-DscResource cmdlet and related features."
-                }
-            )
-        }
     }
 
 }

--- a/src/PSDesiredStateConfiguration/PSDesiredStateConfiguration.psm1
+++ b/src/PSDesiredStateConfiguration/PSDesiredStateConfiguration.psm1
@@ -4158,10 +4158,8 @@ function GetResourceFromKeyword
         Ascending  = $true
     }
     $resource.UpdateProperties($updatedProperties)
-    if ([ExperimentalFeature]::IsEnabled("PSDesiredStateConfiguration.InvokeDscResource"))
-    {
-        $resource | Add-Member -MemberType NoteProperty -Name 'ImplementationDetail' -Value $implementationDetail
-    }
+    
+    $resource | Add-Member -MemberType NoteProperty -Name 'ImplementationDetail' -Value $implementationDetail
 
     return $resource
 }
@@ -4594,7 +4592,6 @@ Export-ModuleMember -Function Get-DscResource, Configuration
 
 function Invoke-DscResource
 {
-    [Experimental("PSDesiredStateConfiguration.InvokeDscResource", "Show")]
     [CmdletBinding(HelpUri = '')]
     param (
         [Parameter(ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, Mandatory)]


### PR DESCRIPTION
This experimental feature was inherited from v2.0.5 and is no longer valid; 
`Invoke-DscResource` cmdlet should not be hidden behind this experimental feature.