### PR TITLE
(AB#5129) Add issue templates and configuration

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_Report.yaml
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.yaml
@@ -1,0 +1,77 @@
+name: Bug report 🐛
+description: Report errors or unexpected behavior 🤔
+labels:
+  - bug
+  - Needs-Triage
+body:
+- type: markdown
+  attributes:
+    value: >-
+      This repository is **ONLY** for issues related to DSC in the published
+      PSDesiredStateConfiguration module.
+- type: checkboxes
+  attributes:
+    label: Prerequisites
+    options:
+    - label: Write a descriptive title.
+      required: true
+    - label: Make sure you are able to repro it on the [latest released version](https://www.powershellgallery.com/packages/PSDesiredStateConfiguration)
+      required: true
+    - label: Search the existing issues.
+      required: true
+- type: textarea
+  attributes:
+    label: Steps to reproduce
+    description: >
+      List of steps, sample code, failing test or link to a project that reproduces the behavior.
+      Make sure you place a stack trace inside a code (```) block to avoid linking unrelated issues.
+    placeholder: >
+      I am experiencing a problem with X.
+      I think Y should be happening but Z is actually happening.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Expected behavior
+    render: console
+    placeholder: |
+      PS> 2 + 2
+      4
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Actual behavior
+    render: console
+    placeholder: |
+      PS> 2 + 2
+      5
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Error details
+    description: Paste verbatim output from `Get-Error` if PowerShell returns an error.
+    render: console
+    placeholder: PS> Get-Error
+- type: textarea
+  attributes:
+    label: Environment data
+    description: Paste verbatim output from `$PSVersionTable` below.
+    render: PowerShell
+    placeholder: PS> $PSVersionTable
+  validations:
+    required: true
+- type: input
+  validations:
+    required: true
+  attributes:
+    label: Version
+    description: Specify the version of Crescendo you are using.
+- type: textarea
+  attributes:
+    label: Visuals
+    description: >
+      Please upload images or animations that can be used to reproduce issues in the area below.
+      Try the [Steps Recorder](https://support.microsoft.com/en-us/windows/record-steps-to-reproduce-a-problem-46582a9b-620f-2e36-00c9-04e25d784e47)
+      on Windows or [Screenshot](https://support.apple.com/en-us/HT208721) on macOS.

--- a/.github/ISSUE_TEMPLATE/Feature_Request.yaml
+++ b/.github/ISSUE_TEMPLATE/Feature_Request.yaml
@@ -1,0 +1,23 @@
+name: Feature Request / Idea 🚀
+description: Suggest a new feature or improvement (this does not mean you have to implement it)
+labels:
+  - enhancement
+  - Needs-Triage
+body:
+- type: textarea
+  attributes:
+    label: Summary of the new feature / enhancement
+    description: >
+      A clear and concise description of what the problem is that the new feature would solve. Try
+      formulating it in user story style (if applicable).
+    placeholder: >
+      'As a user I want X so that Y...' with X being the being the action and Y being the value of
+      the action.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Proposed technical implementation details (optional)
+    placeholder: >
+      A clear and concise description of what you want to happen. Consider providing an example
+      experience with expected result.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,17 @@
+blank_issues_enabled: false
+contact_links:
+  - name: PowerShell Issues
+    url: https://github.com/PowerShell/PowerShell/issues/new
+    about: PowerShell issues or suggestions.
+  - name: Windows PowerShell Issues
+    url: https://support.microsoft.com/windows/send-feedback-to-microsoft-with-the-feedback-hub-app-f59187f8-8739-22d6-ba93-f66612949332
+    about: Windows PowerShell issues or suggestions.
+  - name: Support
+    url: https://github.com/PowerShell/PowerShell/blob/master/.github/SUPPORT.md
+    about: PowerShell Support Questions/Help
+  - name: Documentation Issue
+    url: https://github.com/MicrosoftDocs/PowerShell-Docs-DSC/issues/new/choose
+    about: Please open issues on documentation for DSC here.
+  - name: Azure Policy Feedback
+    about: File feedback for Azure Policy's machine configuration feature
+    url: https://feedback.azure.com/d365community/forum/675ae472-f324-ec11-b6e6-000d3a4f0da0


### PR DESCRIPTION
# PR Summary

This change replaces the default issue templates with YAML issue templates based on those used across the other PowerShell modules.

It introduces configuration for the issues, including links to filing feedback for PowerShell, Windows PowerShell, documentation, and Azure Policy (as **PSDesiredStateConfiguration** v2+ is users of Azure Policy's machine configuration feature).

## PR Context

This change helps to standardize the UX for folks filing feedback for PowerShell modules and ensures that users looking to file docs issues can go directly to the appropriate issue picker.
