### PR TITLE
Change ErrorAction to Ignore so that the error doesn't show up in $Error

### DIFF
--- a/src/PSDesiredStateConfiguration/PSDesiredStateConfiguration.psm1
+++ b/src/PSDesiredStateConfiguration/PSDesiredStateConfiguration.psm1
@@ -71,7 +71,7 @@ data LocalizedData
 Set-StrictMode -Off
 
 # In case localized resource is not available we revert back to English as defined in LocalizedData section so ignore the error instead of showing it to user.
-Import-LocalizedData  -BindingVariable LocalizedData -FileName PSDesiredStateConfiguration.Resource.psd1 -ErrorAction SilentlyContinue
+Import-LocalizedData  -BindingVariable LocalizedData -FileName PSDesiredStateConfiguration.Resource.psd1 -ErrorAction Ignore
 
 Import-Module $PSScriptRoot/helpers/DscResourceInfo.psm1
 
@@ -3481,7 +3481,7 @@ function New-DscChecksum
         }
 
         # If the Force parameter was not specified and the hash file already exists for the current file, log this, and skip this file
-        if (!$Force -and (Get-Item -Path $fileOutpath -ErrorAction SilentlyContinue))
+        if (!$Force -and (Get-Item -Path $fileOutpath -ErrorAction Ignore))
         {
             Write-Log -Message ($LocalizedData.CheckSumFileExists -f $fileOutpath)
             continue


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Previously it was setting `-ErrorAction` to `SilentlyContinue` which on failure will still put the error onto `$Error` and this can confuse users who check on `$Error` to see if any error occurred.  Since the intent is to ignore the error, the right value to use is `Ignore`.

