### PR TITLE
v2 - Fixed Invoke-DscResource error when a class-based resource module path contains a space

### DIFF
--- a/CHANGELOG/v2.md
+++ b/CHANGELOG/v2.md
@@ -1,5 +1,13 @@
 # v2 Changelog
 
+## [v2.0.7]
+
+### Main changes
+
+- Fixed Invoke-DscResource error when a class-based resource module path contains a space.
+
+[v2.0.7]: https://www.powershellgallery.com/packages/PSDesiredStateConfiguration/2.0.7
+
 ## [v2.0.6]
 
 ### Main changes

--- a/src/PSDesiredStateConfiguration/PSDesiredStateConfiguration.psd1
+++ b/src/PSDesiredStateConfiguration/PSDesiredStateConfiguration.psd1
@@ -9,7 +9,7 @@
 RootModule = 'PSDesiredStateConfiguration.psm1'
 
 # Version number of this module.
-moduleVersion = '2.0.6'
+moduleVersion = '2.0.7'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Core')

--- a/src/PSDesiredStateConfiguration/PSDesiredStateConfiguration.psm1
+++ b/src/PSDesiredStateConfiguration/PSDesiredStateConfiguration.psm1
@@ -4749,7 +4749,7 @@ function Invoke-DscClassBasedResource
     $iss = [System.Management.Automation.Runspaces.InitialSessionState]::CreateDefault2()
     $powershell = [PowerShell]::Create($iss)
     $script = @"
-using module $path
+using module "$path"
 
 Write-Host -Message ([$type]::new | out-string)
 return [$type]::new()


### PR DESCRIPTION
# PR Summary

Fix #73 in v2.
