### PR TITLE
ConvertTo-MOFInstance: Include resource properties with empty array value

### DIFF
--- a/src/PSDesiredStateConfiguration/PSDesiredStateConfiguration.psm1
+++ b/src/PSDesiredStateConfiguration/PSDesiredStateConfiguration.psm1
@@ -671,10 +671,7 @@ function ConvertTo-MOFInstance
                     }
                     else
                     {
-                        if ($targetTypeName -notmatch 'Array' -or $p.Value.Count)
-                        {
-                            $p.Name + ' = ' + (stringify -value $p.Value -asArray $asArray -targetType  $targetType ) + ";`n"
-                        }
+                        $p.Name + ' = ' + (stringify -value $p.Value -asArray $asArray -targetType  $targetType ) + ";`n"
                     }
                 }
             }

--- a/test/PSDesiredStateConfiguration.Tests.ps1
+++ b/test/PSDesiredStateConfiguration.Tests.ps1
@@ -439,4 +439,31 @@ MultiResourceConfig -OutputPath TestDrive:\MultiResourceConfig
         "TestDrive:\MultiResourceConfig\localhost.mof" | Should -Exist
         Get-Content -Raw -Path "TestDrive:\MultiResourceConfig\localhost.mof" | Write-Verbose -Verbose
     }
+
+    It "Check empty array compilation" {
+
+        [Scriptblock]::Create(@"
+configuration DSCEmptyArrayConfig
+{
+    Import-DscResource -ModuleName xTestClassResource
+    Node "localhost" {
+        xTestClassResource f2
+        {
+            Name = 'TestName'
+            Value = 'TestValue'
+
+            sArray = @()
+        }
+    }
+}
+
+DSCEmptyArrayConfig -OutputPath TestDrive:\DSCEmptyArrayConfig
+"@) | Should -Not -Throw
+
+        "TestDrive:\DSCEmptyArrayConfig\localhost.mof" | Should -Exist
+
+        $mofContent = Get-Content -Raw -Path "TestDrive:\DSCEmptyArrayConfig\localhost.mof"
+        $mofContent | Write-Verbose -Verbose
+        $mofContent -match '\ssArray\s=\s{\r\n};' | Should -BeTrue
+    }
 }


### PR DESCRIPTION
# PR Summary

Fixes #126 

## PR Context

When switching from Windows PowerShell 5.1 to PowerShell 7 for DSC MOF compilation people are expecting no changes to the resulting MOF files. This is currently not the case for resource properties with an empty array value.
