### PR TITLE
Fixed an issue with array parameters is key-value pairs (#128)

### DIFF
--- a/CHANGELOG/v2.md
+++ b/CHANGELOG/v2.md
@@ -5,6 +5,7 @@
 ### Main changes
 
 - Fixed Invoke-DscResource error when a class-based resource module path contains a space.
+- Fixed an issue with array parameters is key-value pairs (#128).
 
 [v2.0.7]: https://www.powershellgallery.com/packages/PSDesiredStateConfiguration/2.0.7
 

--- a/src/PSDesiredStateConfiguration/PSDesiredStateConfiguration.psm1
+++ b/src/PSDesiredStateConfiguration/PSDesiredStateConfiguration.psm1
@@ -509,7 +509,7 @@ function ConvertTo-MOFInstance
                 $targetTypeName = $PropertyTypes[$p.Name].TypeConstraint
 
                 # see if the target type is an array
-                $asArray = $p.Name -eq 'DependsOn' -or $targetTypeName -match 'Array'
+                $asArray = $p.Name -eq 'DependsOn' -or $targetTypeName -match 'Array' -or ((-not [string]::IsNullOrEmpty($targetTypeName)) -and $targetTypeName.EndsWith('[]'))
 
                 # Convert the CIM typename to the appropriate .NET type to use
                 # to convert the input object into an appropriately encoded string

--- a/test/PSDesiredStateConfiguration.Tests.ps1
+++ b/test/PSDesiredStateConfiguration.Tests.ps1
@@ -302,6 +302,8 @@ Describe "All types DSC resource tests" {
                 "uInt32ValueArray" {$dscResourcePropertyInfo.PropertyType |  Should -Be '[UInt32[]]'}
                 "uInt64Value" {$dscResourcePropertyInfo.PropertyType |  Should -Be '[UInt64]'}
                 "uInt64ValueArray" {$dscResourcePropertyInfo.PropertyType |  Should -Be '[UInt64[]]'}
+
+                "HashTableValue" {$dscResourcePropertyInfo.PropertyType |  Should -Be '[Hashtable]'}
             }
         }
     }
@@ -349,6 +351,8 @@ Describe "All types DSC resource tests" {
         $resource.uInt32ValueArray.GetType().Name | Should -Be "UInt32[]"
         $resource.uInt64Value.GetType().Name | Should -Be "UInt64"
         $resource.uInt64ValueArray.GetType().Name | Should -Be "UInt64[]"
+
+        $resource.HashTableValue.GetType().Name | Should -Be "Hashtable"
 
         # extra check for embedded objects
         $resource.EmbClassObj.EmbClassStr1 | Should -Be "TestEmbObjValue"
@@ -400,6 +404,11 @@ configuration DSCAllTypesConfig
             sInt32ValueArray = @(-2147483648)
             uInt64ValueArray = @(18446744073709551615)
             sInt64ValueArray = @(-9223372036854775808)
+
+            HashTableValue = @{
+                Key1 = 'Value1'
+                Key2 = 'Value2'
+            }
         }
     }
 }

--- a/test/TestModules/xTestClassResource/xTestClassResource.psm1
+++ b/test/TestModules/xTestClassResource/xTestClassResource.psm1
@@ -109,6 +109,9 @@ class xTestClassResource
     [DscProperty()]
     [Char[]] $char16ValueArray;
 
+    [DscProperty()]
+    [hashtable] $HashTableValue;
+
     [void] Set()
     {
 
@@ -256,6 +259,8 @@ class xTestClassResource
 
         $this.Real32ValueArray = [single[]]::new(0)
         $this.Real64ValueArray = [double[]]::new(0)
+
+        $this.HashTableValue = @{}
 
         return $this
     }


### PR DESCRIPTION
# PR Summary

Fixed an issue with array parameters is key-value pairs (#128).

## PR Context

There is a bug in the PSDesiredStateConfiguration 2.0.7 that makes it unusable in some scenarios. The issue is described in #128. The bug does not exist in PSDesiredStateConfiguration  1.0. This PR fixes that.
